### PR TITLE
removed trailing slash that break paths on OSX

### DIFF
--- a/bin/swat
+++ b/bin/swat
@@ -88,7 +88,7 @@ mkdir -p $reports_dir
 
 tt=1
 
-for f in `find $project/ -type f -name get.txt -o -name post.txt -o -name put.txt`; do
+for f in `find $project -type f -name get.txt -o -name post.txt -o -name put.txt`; do
 
     route_dir=`perl -MFile::Spec -e '$sp=$ARGV[0]; s{\w+\.txt$}[] for $sp; chomp $sp; print File::Spec->rel2abs($sp)' $f`;
 


### PR DESCRIPTION
Hi, ionOSX, paths are created with 2 slashes after host:port.
